### PR TITLE
replace mailchimp for nodemailer Closes #6

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,7 @@
   "env": {
     "es6": true,
     "node": true,
-    "browser": true
+    "browser": false
   },
   "ecmaFeatures": {
     "modules": true

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# notifier
+# DemocracyOS Notifier
 Embeddable notifications engine that relies on MongoDB for job queuing and scheduling. Powered by rschmukler/agenda
+
+## Mailer Configuration
+
+Uses [NodeMailer](https://www.npmjs.com/package/nodemailer) package for email handling. Available services are the ones listed on the [nodemailer-wellknown](https://github.com/andris9/nodemailer-wellknown#supported-services) repo.
+
+### SendGrid Example
+
+```javascript
+var notifier = require('democracyos-notifier')({
+  service: 'sendgrid',
+  auth: {
+    user: 'fake-sendgrid-user!@sendgrid.com',
+    pass: 'fake-sendgrid-pass'
+  }
+})
+```
+
+### Gmail Example
+
+```javascript
+var notifier = require('democracyos-notifier')({
+  service: 'gmail',
+  auth: {
+    user: 'fake-gmail-user!@gmail.com',
+    pass: 'fake-gmail-pass'
+  }
+})
+```
+
+### Direct Transport Example
+
+Not recommended for `production`. Using direct transport is not reliable as outgoing port 25 used is often blocked by default. Additionally mail sent from dynamic addresses is often flagged as spam. You should really consider using a SMTP provider.
+
+```javascript
+var notifier = require('democracyos-notifier')()
+```

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Uses [NodeMailer](https://www.npmjs.com/package/nodemailer) package for email ha
 
 ```javascript
 var notifier = require('democracyos-notifier')({
-  service: 'sendgrid',
-  auth: {
-    user: 'fake-sendgrid-user!@sendgrid.com',
-    pass: 'fake-sendgrid-pass'
+  mailer: {
+    service: 'sendgrid',
+    auth: {
+      user: 'fake-sendgrid-user!@sendgrid.com',
+      pass: 'fake-sendgrid-pass'
+    }
   }
 })
 ```
@@ -21,10 +23,12 @@ var notifier = require('democracyos-notifier')({
 
 ```javascript
 var notifier = require('democracyos-notifier')({
-  service: 'gmail',
-  auth: {
-    user: 'fake-gmail-user!@gmail.com',
-    pass: 'fake-gmail-pass'
+  mailer: {
+    service: 'gmail',
+    auth: {
+      user: 'fake-gmail-user!@gmail.com',
+      pass: 'fake-gmail-pass'
+    }
   }
 })
 ```

--- a/index.js
+++ b/index.js
@@ -1,18 +1,16 @@
-/**
- * Module dependencies.
- */
-
+var defaults = require('defaults-deep')
 var agenda = require('./lib/agenda')
 var timing = require('./lib/utils/timing')
-var log = require('debug')('democracyos:notifier')
 var jobs = require('./lib/jobs')
-
-// fix this with an var exports=module.exports =function and just rewriting exports
 var transports = require('./lib/transports')
 
-var defaults = {
+var log = require('debug')('democracyos:notifier')
+
+var defaultOpts = {
   mongoUrl: 'mongodb://localhost/DemocracyOS-dev',
   collection: 'notifierJobs',
+  organizationName: 'noreply@democracyos.org',
+  organizationEmail: 'The DemocracyOS team',
   mailer: {
     service: '',
     auth: {
@@ -23,12 +21,16 @@ var defaults = {
 }
 
 var exports = module.exports = function startNotifier(opts, callback) {
-  var mongoUrl = opts.mongoUrl || defaults.mongoUrl
-  var collection = opts.collection || defaults.collection
-  var mailer = opts.mailer || defaults.mailer
+  defaults(opts, defaultOpts)
 
-  agenda = agenda({db: {address: mongoUrl, collection: collection} })
-  transports = transports(mailer)
+  agenda = agenda({
+    db: {
+      address: opts.mongoUrl,
+      collection: opts.collection
+    }
+  })
+
+  transports = transports(opts)
 
   agenda.purge(function (err) {
     if (err) return callback && callback(err)

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ var exports = module.exports = function startNotifier(opts, callback) {
     if (err) return callback && callback(err)
 
     //initialize job processors
-    jobs(agenda, mongoUrl)
+    jobs(agenda, opts.mongoUrl)
 
     agenda.on('start', function (job) {
       timing.start(job)

--- a/index.js
+++ b/index.js
@@ -13,16 +13,22 @@ var transports = require('./lib/transports')
 var defaults = {
   mongoUrl: 'mongodb://localhost/DemocracyOS-dev',
   collection: 'notifierJobs',
-  mandrillToken: 'fake-mandrill-token',
+  mailer: {
+    service: '',
+    auth: {
+      user: '',
+      pass: ''
+    }
+  }
 }
 
 var exports = module.exports = function startNotifier(opts, callback) {
   var mongoUrl = opts.mongoUrl || defaults.mongoUrl
   var collection = opts.collection || defaults.collection
-  var mandrillToken = opts.mandrillToken || defaults.mandrillToken
+  var mailer = opts.mailer || defaults.mailer
 
   agenda = agenda({db: {address: mongoUrl, collection: collection} })
-  transports = transports({mandrillToken: mandrillToken})
+  transports = transports(mailer)
 
   agenda.purge(function (err) {
     if (err) return callback && callback(err)

--- a/lib/transports/index.js
+++ b/lib/transports/index.js
@@ -53,9 +53,15 @@ function resolveRecipient(rec) {
  * Module exports
  */
 var exports = module.exports = function transports(config) {
-  var transport = createTransport(config)
+  var transport = createTransport(config.mailer)
 
   exports.mail = function (opts, callback){
+    if (!opts.from && config.organizationName && config.organizationEmail) {
+      opts.from = {
+        email: config.organizationEmail,
+        name: config.organizationName
+      }
+    }
     sendMail(transport, opts, callback)
   }
 }

--- a/lib/transports/index.js
+++ b/lib/transports/index.js
@@ -1,48 +1,50 @@
-var mandrill = require('node-mandrill')
+var nodemailer = require('nodemailer')
 var templates = require('../templates')
 var t = require('../translations').t
 var log = require('debug')('democracyos:notifier:transports')
 
-function setupMandrill(token) {
-  if (!token || 'string' != typeof token) {
-    throw new Error('Undefined or invalid mandrill API token')
-  }
-
-  log('Initializing mandrill API client')
-  return mandrill(token)
+function createTransport(config) {
+  log('Initializing nodemailer API client')
+  var opts = config && config.service ? config : undefined
+  return nodemailer.createTransport(opts)
 }
 
-function sendMandrill(opts, callback) {
+function sendMail(transport, opts, callback) {
   var to = resolveRecipient(opts.to)
-  var from = opts.from || { email: 'noreply@democracyos.org', name: 'The DemocracyOS team' }
+  var from = resolveRecipient(opts.from || {
+    email: 'noreply@democracyos.org',
+    name: 'The DemocracyOS team'
+  })
 
   // get mail body from jade template
   templates.jade(opts.template, opts.vars, function (err, body) {
-    if (err) return callback(err);
+    if (err) return callback(err)
 
     log('Sending email for "%s" job', opts.template)
 
-    mandrill('/messages/send', {
-      message: {
-        to: to,
-        from_email: from.email,
-        from_name: from.name,
-        subject: t('templates.' + opts.template + '.subject'),
-        html: body
-      }
+    transport.sendMail({
+      from: from,
+      to: to,
+      subject: t('templates.' + opts.template + '.subject'),
+      html: body
     }, function (err, response) {
-      if (err) log('Mandrill API error: %j', err)
-      else log('Mandrill send successful: %j', response)
+      if (err) log('Nodemailer API error: %j', err)
+      else log('Nodemailer send successful: %j', response)
 
       if (callback) callback(err)
     })
   })
 }
 
-function resolveRecipient(obj) {
-  if (Array.isArray(obj)) return obj
-  if ('object' === typeof obj) return [obj]
-  if ('string' === typeof obj) return { email: obj }
+function resolveRecipient(rec) {
+  if ('string' === typeof rec) return rec
+
+  if ('object' === typeof rec) {
+    if (rec.name) return rec.name + ' <' + rec.email + '>'
+    return rec.email
+  }
+
+  if (Array.isArray(rec)) return rec.map(resolveRecipient)
 
   throw new Error('Invalid or undefined recipient object')
 }
@@ -51,8 +53,9 @@ function resolveRecipient(obj) {
  * Module exports
  */
 var exports = module.exports = function transports(config) {
+  var transport = createTransport(config)
 
-  // setup mandrill
-  mandrill = setupMandrill(config.mandrillToken)
-  exports.mail = sendMandrill
+  exports.mail = function (opts, callback){
+    sendMail(transport, opts, callback)
+  }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "moment": "2.9.0",
     "mongojs": "^1.2.1",
     "node-mandrill": "^1.0.1",
+    "nodemailer": "^1.4.0",
     "require-all": "^1.1.0",
     "t-component": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "jade": "^1.11.0",
     "moment": "2.9.0",
     "mongojs": "^1.2.1",
-    "node-mandrill": "^1.0.1",
     "nodemailer": "^1.4.0",
     "require-all": "^1.1.0",
     "t-component": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "agenda": "^0.6.28",
     "async": "^1.4.0",
     "debug": "^2.2.0",
+    "defaults-deep": "^0.2.3",
     "jade": "^1.11.0",
     "moment": "2.9.0",
     "mongojs": "^1.2.1",


### PR DESCRIPTION
Uses [NodeMailer](https://www.npmjs.com/package/nodemailer) package.

Usage examples added to `README.md`

Should be tested and accepted with:
- https://github.com/DemocracyOS/app/pull/1029
- https://github.com/DemocracyOS/notifier-server/pull/44
