### PR TITLE
Update MongoDB connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function init(opts, callback){
     })
 
     agenda.on('fail', function (err, job) {
-      log('Job \'%s\' failed - reason: %s',job.attrs.name, err)
+      log('Job \'%s\' failed - reason: %s', job.attrs.name, err)
     })
 
     agenda.start()

--- a/index.js
+++ b/index.js
@@ -32,6 +32,21 @@ var exports = module.exports = function startNotifier(opts, callback) {
 
   transports = transports(opts)
 
+  setTimeout(function verifyInitialization(){
+    if (!agenda._collection) {
+      log('initializing agenda...')
+      return setTimeout(verifyInitialization, 100)
+    }
+    log('agenda initialized.')
+    init(opts, callback)
+  }, 100)
+
+  exports.notify = function notify(event, callback) {
+    jobs.process(event.event, event, callback)
+  }
+}
+
+function init(opts, callback){
   agenda.purge(function (err) {
     if (err) return callback && callback(err)
 
@@ -53,11 +68,6 @@ var exports = module.exports = function startNotifier(opts, callback) {
     })
 
     agenda.start()
-
     if (callback) return callback()
   })
-
-  exports.notify = function notify(event, callback) {
-    jobs.process(event.event, event, callback)
-  }
 }

--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -6,7 +6,7 @@ module.exports = function connectToMongoDB (mongoUrl) {
   }
 
   // connect to db
-  var db = mongo(mongoUrl, ['users', 'topics', 'tags', 'feeds'])
+  var db = mongo(mongoUrl, ['users', 'topics', 'tags', 'feeds'], {authMechanism: 'ScramSHA1'})
 
   if (!db) throw new Error('could not connect to ' + config.connection)
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/DemocracyOS/notifier",
   "dependencies": {
-    "agenda": "^0.6.28",
+    "agenda": "DemocracyOS/agenda",
     "async": "^1.4.0",
     "debug": "^2.2.0",
     "defaults-deep": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "defaults-deep": "^0.2.3",
     "jade": "^1.11.0",
     "moment": "2.9.0",
-    "mongojs": "^1.2.1",
+    "mongojs": "^1.3.0",
     "nodemailer": "^1.4.0",
     "require-all": "^1.1.0",
     "t-component": "^1.0.0"


### PR DESCRIPTION
- Uses an `agenda` version with `mongodb-native` instead of `mongoskin`, taken from here: https://github.com/rschmukler/agenda/pull/205
- Loads agenda async. (TODO: Fix the ugly `setTimeout` until is loaded).
- Updates `mongojs` and forcefully uses `{authMechanism: 'ScramSHA1'}`
