### PR TITLE
Disable topic published mail sending

### DIFF
--- a/lib/jobs/lib/topic-published.js
+++ b/lib/jobs/lib/topic-published.js
@@ -10,43 +10,45 @@ var jobNameForSingleUser = 'topic-published-single-recipient'
 var jobNameForUpdateFeed = require('./update-feed.js').jobName
 
 module.exports = function (opts) {
-  db = db(opts.mongoUrl)
-  opts.eventsAndJobs[jobName] = jobName
-  opts.eventsAndJobs[jobNameForSingleUser] = jobNameForSingleUser
+  // NOTICE: this job was commented out to disable it in pro
 
-  opts.agenda.define(jobName, function (job, done) {
-    var data = job.attrs.data
+  // db = db(opts.mongoUrl)
+  // opts.eventsAndJobs[jobName] = jobName
+  // opts.eventsAndJobs[jobNameForSingleUser] = jobNameForSingleUser
 
-    jobs.process(jobNameForUpdateFeed, data.topic, done)
+  // opts.agenda.define(jobName, function (job, done) {
+  //   var data = job.attrs.data
 
-    db.users.find({ 'notifications.new-topic': true }, function (err, users) {
-      if (err) return done(err)
+  //   jobs.process(jobNameForUpdateFeed, data.topic, done)
 
-      async.each(users, function(u, cb) {
-        jobs.process(jobNameForSingleUser,{
-          topic: data.topic,
-          url: data.url,
-          to: { name: name.format(u), email: u.email }
-        }, cb)
-      }, done)
-    })
-  })
+  //   db.users.find({ 'notifications.new-topic': true }, function (err, users) {
+  //     if (err) return done(err)
 
-  opts.agenda.define(jobNameForSingleUser, function (job, done) {
-    // email and user *will* exist because only a 'topic-public'
-    // may trigger this job and that queary already scans the DB
-    var data = job.attrs.data
+  //     async.each(users, function(u, cb) {
+  //       jobs.process(jobNameForSingleUser,{
+  //         topic: data.topic,
+  //         url: data.url,
+  //         to: { name: name.format(u), email: u.email }
+  //       }, cb)
+  //     }, done)
+  //   })
+  // })
 
-    var params = {
-      template: jobName,
-      to: data.to,
-      vars: [
-        { name: 'TOPIC', content: data.topic.mediaTitle },
-        { name: 'URL', content: data.url },
-        { name: 'USER_NAME', content: data.to.name }
-      ]
-    }
+  // opts.agenda.define(jobNameForSingleUser, function (job, done) {
+  //   // email and user *will* exist because only a 'topic-public'
+  //   // may trigger this job and that queary already scans the DB
+  //   var data = job.attrs.data
 
-    mail(params, done)
-  })
+  //   var params = {
+  //     template: jobName,
+  //     to: data.to,
+  //     vars: [
+  //       { name: 'TOPIC', content: data.topic.mediaTitle },
+  //       { name: 'URL', content: data.url },
+  //       { name: 'USER_NAME', content: data.to.name }
+  //     ]
+  //   }
+
+  //   mail(params, done)
+  // })
 }


### PR DESCRIPTION
When SaaS is enabled, users will get swamped by default with mails about everything that's published in it. This is a quick & dirty fix for that.
