### PR TITLE
replace jade and upgrade mongojs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/DemocracyOS/notifier.git"
+    "url": "https://github.com/gabx/notifier.git"
   },
   "keywords": [
     "notifier",
@@ -21,15 +21,15 @@
   "bugs": {
     "url": "https://github.com/DemocracyOS/notifier/issues"
   },
-  "homepage": "https://github.com/DemocracyOS/notifier",
+  "homepage": "https://github.com/gabx/notifier",
   "dependencies": {
-    "agenda": "DemocracyOS/agenda",
+    "agenda": "http://github.com/DemocracyOS/agenda",
     "async": "^1.4.0",
     "debug": "^2.2.0",
     "defaults-deep": "^0.2.3",
-    "jade": "^1.11.0",
+    "pug": "2.0.0-beta6", 
     "moment": "2.9.0",
-    "mongojs": "^1.3.0",
+    "mongojs": "^2.4.0",
     "nodemailer": "^1.4.0",
     "require-all": "^1.1.0",
     "t-component": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gabx/notifier.git"
+    "url": "https://github.com/DemocracyOS/notifier.git"
   },
   "keywords": [
     "notifier",
@@ -21,9 +21,9 @@
   "bugs": {
     "url": "https://github.com/DemocracyOS/notifier/issues"
   },
-  "homepage": "https://github.com/gabx/notifier",
+  "homepage": "https://github.com/DemocracyOS/notifier",
   "dependencies": {
-    "agenda": "http://github.com/DemocracyOS/agenda",
+    "agenda": "DemocracyOS/agenda",
     "async": "^1.4.0",
     "debug": "^2.2.0",
     "defaults-deep": "^0.2.3",


### PR DESCRIPTION
Jade has been renamed to pug
upgrade mongojs to 2.4.0 needed to upgrade democracyOS app
