### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debug": "2.2.0",
     "defaults-deep": "0.2.3",
     "pug": "2.0.0-beta6",
-    "moment": "2.9.0",
+    "moment": "2.15.2",
     "mongojs": "2.4.0",
     "nodemailer": "2.6.4",
     "require-all": "2.0.0",


### PR DESCRIPTION
notifier is currently affected by the medium-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:moment:20161019). 

Vulnerable module: `moment`
Introduced through: `moment`

This PR fixes the ReDoS vulnerability by upgrading `moment` to version 2.15.2 This upgrade will also fix the following other vulnerabilities:
- [low-severity ReDos vulnerabilty](https://snyk.io/vuln/npm:moment:20160126) in the `moment` dependency.

Check out the [Snyk test report](https://snyk.io/test/github/democracyos/notifier) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
- get alerts if newly disclosed vulnerabilities affect this repo in the future. 
- generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team
